### PR TITLE
fix native build, adding README Fedora 40 packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,10 +201,18 @@ on `http://localhost:4200` by running
 ## Native build
 
 Building the native version of CloudpilotEmu requires SDL2 and a recent version
-of Boost. On Ubuntu the following will give you the necessary packages:
+of Boost. 
+
+On Ubuntu the following will give you the necessary packages:
 
 ```
     $ apt-get install libreadline-dev libboost-all-dev libsdl2-image-dev libsdl2-dev
+```
+
+On Fedora
+
+```
+    $ dnf install readline-devel boost-devel SDL2_image-devel SDL2-devel 
 ```
 
 The build is accomplished with

--- a/src/cloudpilot/emulator/Miscellaneous.cpp
+++ b/src/cloudpilot/emulator/Miscellaneous.cpp
@@ -1,5 +1,5 @@
 #include "Miscellaneous.h"
-
+#include <algorithm>
 #include "Byteswapping.h"
 #include "EmBankMapped.h"
 #include "EmLowMem.h"

--- a/src/common/zip/zip.c
+++ b/src/common/zip/zip.c
@@ -1525,7 +1525,7 @@ ssize_t zip_stream_copy(struct zip_t *zip, void **buf, ssize_t *bufsize) {
   if (bufsize != NULL) {
     *bufsize = zip->archive.m_archive_size;
   }
-  *buf = calloc(sizeof(unsigned char), zip->archive.m_archive_size);
+  *buf = calloc(zip->archive.m_archive_size, sizeof(unsigned char));
   memcpy(*buf, zip->archive.m_pState->m_pMem, zip->archive.m_archive_size);
 
   return zip->archive.m_archive_size;


### PR DESCRIPTION
Hi, cannot build native version therefore patch below:

Error1
`
make -Csrc bin
make[1]: Entering directory '/home/kevit/Public/Palm/cloudpilot-emu/src'
for subdir in common skins cloudpilot fstools vfs uarm; do make -C$subdir bin || exit 1; done
make[2]: Entering directory '/home/kevit/Public/Palm/cloudpilot-emu/src/common'
mkdir -p .build/zip/ && mkdir -p .deps/zip/ && gcc -MT .build/zip/miniz.o -MMD -MP -MF .deps/zip/miniz.d -Werror -Wextra -Wall -Wno-unused-parameter -std=gnu99 -O2  -g  -I. -c -o .build/zip/miniz.o zip/miniz.c
mkdir -p .build/zip/ && mkdir -p .deps/zip/ && gcc -MT .build/zip/zip.o -MMD -MP -MF .deps/zip/zip.d -Werror -Wextra -Wall -Wno-unused-parameter -std=gnu99 -O2  -g  -I. -c -o .build/zip/zip.o zip/zip.c
zip/zip.c: In function ‘zip_stream_copy’:
zip/zip.c:1528:24: error: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
 1528 |   *buf = calloc(sizeof(unsigned char), zip->archive.m_archive_size);
      |                        ^~~~~~~~
zip/zip.c:1528:24: note: earlier argument should specify number of elements, later size of each element
cc1: all warnings being treated as errors
make[2]: *** [Makefile:113: .build/zip/zip.o] Error 1
make[2]: Leaving directory '/home/kevit/Public/Palm/cloudpilot-emu/src/common'
make[1]: *** [Makefile:6: bin] Error 1
make[1]: Leaving directory '/home/kevit/Public/Palm/cloudpilot-emu/src'
make: *** [Makefile:4: bin] Error 2
`
Fix 1

`
 -  *buf = calloc(sizeof(unsigned char), zip->archive.m_archive_size);
 + *buf = calloc(zip->archive.m_archive_size, sizeof(unsigned char));
`

Error2

```
emulator/Miscellaneous.cpp: In function ‘bool GetDatabases(DatabaseInfoList&, uint32)’:
emulator/Miscellaneous.cpp:718:5: error: ‘sort’ was not declared in this scope; did you mean ‘short’?
  718 |     sort(dbList.begin(), dbList.end(), AppCompareDataBaseNames);
      |     ^~~~
      |     short
emulator/Miscellaneous.cpp: At global scope:
emulator/Miscellaneous.cpp:29:10: error: ‘bool {anonymous}::AppCompareDataBaseNames(const DatabaseInfo&, const DatabaseInfo&)’ defined but not used [-Werror=unused-function]
   29 |     bool AppCompareDataBaseNames(const DatabaseInfo& a, const DatabaseInfo& b) {
      |          ^~~~~~~~~~~~~~~~~~~~~~~
```

Fix 2 

```
#include <algorithm>
``` 
      
