### PR TITLE
cloudpilot-server: Fix incorrect command given after certificates first generated

### DIFF
--- a/server/certificate.py
+++ b/server/certificate.py
@@ -163,7 +163,7 @@ def generateCertificate(options):
 
     print("""...done! You can now launch the server with
 
-> {script} --cert {filePem}
+> {script} serve --cert {filePem}
 
 in order to use the generated certificate. Please check the documentation on
 how to install and trust "{fileCaCer}" on your devices running CloudpilotEmu.


### PR DESCRIPTION
Was:

```
$ ./cloudpilot-server generate-cert
generating certificates...
...done! You can now launch the server with

> ./cloudpilot-server --cert cloudpilot-server.pem

in order to use the generated certificate. Please check the documentation on
how to install and trust "cloudpilot-server-root.cer" on your devices running CloudpilotEmu.
```

The problem is that `> ./cloudpilot-server --cert cloudpilot-server.pem` is not a valid command (`serve` subcommand needs to be given before the `--cert`. This PR fixes that.
