### PR TITLE
Make cp-uarm fail loudly when --gdb is not enabled

### DIFF
--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -52,6 +52,18 @@ The GDB stub is only available in the native version of CloudpilotEmu (and not
 in the web version). Please follow the instructions in [the
 README](../README.md) in order to build it from source.
 
+If you want to use cp-uarm --gdb and cloudpilotemu -l, make sure the CLI is actually built
+with the debugging stub enabled. Add the following to src/Makefile.local:
+
+```
+CFLAGS_NATIVE_EXTRA += -DENABLE_DEBUGGER -DGDB_STUB_ENABLED
+CXXFLAGS_NATIVE_EXTRA += -DENABLE_DEBUGGER -DGDB_STUB_ENABLED
+```
+
+Do not override CFLAGS_NATIVE directly for this. Appending through
+CFLAGS_NATIVE_EXTRA and CXXFLAGS_NATIVE_EXTRA keeps the rest of the project
+build flags intact.
+
 ### Building GDB
 
 A version of GDB built for the target `m68k-none-elf` is required for debugging

--- a/src/uarm/native/main.cpp
+++ b/src/uarm/native/main.cpp
@@ -392,6 +392,15 @@ int main(int argc, const char** argv) {
                        .ramSize = program.present<unsigned int>("--ram-size"),
                        .smallWindow = program.get<bool>("--small-window")};
 
+#ifndef GDB_STUB_ENABLED
+    if (options.gdbPort.has_value()) {
+        cerr << "cp-uarm was built without GDB stub support." << endl;
+        cerr << "Rebuild the native CLI with -DGDB_STUB_ENABLED" << endl;
+        cerr << "for both CFLAGS_NATIVE_EXTRA and CXXFLAGS_NATIVE_EXTRA in src/Makefile.local," << endl;
+        exit(1);
+    }
+#endif
+
     logEnable();
 
     if (!run(options)) exit(1);

--- a/src/uarm/native/main.cpp
+++ b/src/uarm/native/main.cpp
@@ -214,7 +214,8 @@ namespace {
 
         SoC* soc = socInit(romInfo.GetDeviceType(), ramSize, nor.data, nor.size,
                            reinterpret_cast<uint8_t*>(nand.data), nand.size,
-                           options.gdbPort.value_or(0), deviceGetSocRev());
+                           options.gdbPort.has_value() ? static_cast<int>(*options.gdbPort) : -1,
+                           deviceGetSocRev());
 
         if (memory.data && memory.size > socGetMemoryData(soc).size) {
             cerr << "RAM size mismatch" << endl;
@@ -391,6 +392,11 @@ int main(int argc, const char** argv) {
                        .script = program.present("--script"),
                        .ramSize = program.present<unsigned int>("--ram-size"),
                        .smallWindow = program.get<bool>("--small-window")};
+
+    if (options.gdbPort.has_value() && *options.gdbPort == 0) {
+        cerr << "--gdb requires a non-zero port" << endl;
+        exit(1);
+    }
 
 #ifndef GDB_STUB_ENABLED
     if (options.gdbPort.has_value()) {


### PR DESCRIPTION
When running local debug, didn't understand why gdb wasn't listened on, turns out it needs a flag to be available.
Added a note in runtime when it was compiled without the flag and documented in the debugging manual.

Added: do not wait for gdb if it's not passed as parameter to cli.