### PR TITLE
Fix BLX register target handling

### DIFF
--- a/src/uarm/uarm/CPU.cpp
+++ b/src/uarm/uarm/CPU.cpp
@@ -1407,10 +1407,11 @@ template <bool wasT, bool link>
 static void execFn_bl_reg(struct ArmCpu *cpu, uint32_t instr) {
     if (table_conditions[((cpu->flags & 0xf0000000UL) >> 24) | (instr >> 28)]) return;
 
+    const uint32_t ea = cpuPrvGetReg<wasT>(cpu, instr & 0x0F);
     if (link)
         cpuPrvSetRegNotPC(cpu, REG_NO_LR,
                           cpu->curInstrPC + (wasT ? 3 : 4));  // save return value for BLX
-    cpuPrvSetPC(cpu, cpuPrvGetReg<wasT>(cpu, instr & 0x0F));
+    cpuPrvSetPC(cpu, ea);
 }
 
 template <bool wasT, bool spsr>


### PR DESCRIPTION
## Summary

- read the BLX register target before updating the link register
- preserve the original target when executing `BLX LR`

## Root cause

The register branch handler wrote the return address to LR before reading the branch target. When LR was also the source register, the emulator branched to the newly written return address instead of the original target and failed to switch instruction sets correctly.

## Impact

`BLX LR` now branches to the original LR value while still storing the correct return address, including the expected ARM/Thumb state transition.

## Validation

- `make bin`
- local focused CPU validation reproduced the incorrect `0x1004` ARM-state branch before the fix and the expected `0x2000` Thumb-state branch after it